### PR TITLE
FLUID-6316: Move fluid-grunt-eslint to main dependencies block.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "homepage": "http://fluidproject.org",
     "dependencies": {
-        "fluid-grunt-eslint": "18.1.2",
+        "fluid-grunt-eslint": "18.1.2"
     },
     "devDependencies": {
         "grunt": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
         "url": "https://issues.fluidproject.org/projects/FLUID/issues"
     },
     "homepage": "http://fluidproject.org",
+    "dependencies": {
+        "fluid-grunt-eslint": "18.1.2",
+    },
     "devDependencies": {
         "grunt": "1.0.1",
-        "fluid-grunt-eslint": "18.1.2",
         "grunt-jsonlint": "1.1.0"
     }
 }


### PR DESCRIPTION
See [FLUID-6316](https://issues.fluidproject.org/browse/FLUID-6316) for details.